### PR TITLE
removed chroot directive from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Example haproxy config file using acme webroot plugin:
 
 ```
 global
-	chroot /var/lib/haproxy
-
 	# Default SSL material locations
 	crt-base /etc/letsencrypt/live
 


### PR DESCRIPTION
With the directive in place the lua script is not able to load files from /var/acme-challenge, which is the default directory when using the recommended docker-letsencrypt-manager project.
